### PR TITLE
Kafka 설정 및 알림 서비스와 통신 기능 추가

### DIFF
--- a/bin/main/application-test.yml
+++ b/bin/main/application-test.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5433/testdb
+    username: testuser
+    password: ${TEST_DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    show-sql: true
+    format_sql: true

--- a/bin/main/application.yml
+++ b/bin/main/application.yml
@@ -1,4 +1,3 @@
-
 spring:
   mail:
     host: smtp.naver.com  # 또는 smtp.gmail.com
@@ -17,10 +16,9 @@ spring:
       host: localhost
       port: 6379
   datasource:
-    url: ${LOCAL_DB_URL}
-    #    url: jdbc:postgresql://localhost:5432/devdb
-    username: ${LOCAL_DB_USERNAME}
-    password: ${LOCAL_DB_PASSWORD}
+    url: jdbc:postgresql://localhost:5433/user_service
+    username: gucci
+    password: ${POSTGRESQL_DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -40,28 +38,8 @@ spring:
   config:
     import: optional:.env[.properties]
 
-  kafka:
-    bootstrap-servers: localhost:9092
-    producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.apache.kafka.common.serialization.StringSerializer
-
+  server:
+    port: 8081
 jwt:
   secret: ${JWT_SECRET}
-  access-expiration: 60      # 1시간
-  refresh-expiration: 3000   # 50시간
-
-oauth:
-  google:
-    client-id: ${GOOGLE_CLIENT_ID}
-    client-secret: ${GOOGLE_CLIENT_SECRET}
-    redirect-uri: http://localhost:3000/oauth/google/redirect
-  kakao:
-    client-id: ${KAKAO_CLIENT_ID}
-    redirect-uri: http://localhost:3000/oauth/kakao/redirect
-springdoc:
-  swagger-ui:
-    path: /swagger-ui.html
-
-server:
-  port: 8081
+  expiration: 3000 #분단위

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
+//	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
+	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
 
@@ -48,6 +49,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	implementation 'com.github.Gachon-Univ-Creative-Code-Innovation:alog-common:v1.0.1'
+	implementation 'org.springframework.kafka:spring-kafka'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-	implementation 'com.github.Gachon-Univ-Creative-Code-Innovation:alog-common:v1.0.1'
+	implementation 'com.github.Gachon-Univ-Creative-Code-Innovation:alog-common:v1.0.2'
 	implementation 'org.springframework.kafka:spring-kafka'
 
 }

--- a/src/main/java/com/gucci/user_service/kafka/domain/NotificationType.java
+++ b/src/main/java/com/gucci/user_service/kafka/domain/NotificationType.java
@@ -1,0 +1,13 @@
+package com.gucci.user_service.kafka.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationType {
+    FOLLOW("FOLLOW","님이 당신을 팔로우 했어요");
+
+    private final String type;
+    private final String message;
+}

--- a/src/main/java/com/gucci/user_service/kafka/dto/NotificationKafkaRequest.java
+++ b/src/main/java/com/gucci/user_service/kafka/dto/NotificationKafkaRequest.java
@@ -1,0 +1,16 @@
+package com.gucci.user_service.kafka.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationKafkaRequest {
+    private Long receiverId;
+    private Long senderId;
+    private String type;        // 예: FOLLOW
+    private String content;     // 예: OO가 당신을 팔로우 했습니다.
+    private String targetUrl;   // 예: /user/2 or /blog/2 (클릭 시 이동 될 url)
+}

--- a/src/main/java/com/gucci/user_service/kafka/producer/NotificationProducer.java
+++ b/src/main/java/com/gucci/user_service/kafka/producer/NotificationProducer.java
@@ -1,0 +1,21 @@
+package com.gucci.user_service.kafka.producer;
+
+import com.gucci.user_service.kafka.dto.NotificationKafkaRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class NotificationProducer {
+
+    private final KafkaTemplate<String, NotificationKafkaRequest> kafkaTemplate;
+    private static final String TOPIC_NAME = "alarm-topic";
+
+    public void sendNotification(NotificationKafkaRequest message) {
+        log.info("Kafka 메시지 전송: {}", message);
+        kafkaTemplate.send(TOPIC_NAME, message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,9 @@ spring:
     bootstrap-servers: localhost:9092
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## 📌 Jira Issue

- 관련 티켓: [GUC-67](https://sh0314.atlassian.net/browse/GUC-67)
- 관련 GitHub 이슈: #17 

---

## ✨ PR Description

- Kafka의 초기 설정을 구성했습니다. 현재 Producer만 정의했으므로, 수신은 불가하고 발신만 가능합니다.
- 추후에 수신이 필요할 경우 Consumer 코드도 추가하겠습니다.
- 팔로우 성공 시 알림 서비스에 팔로우 정보를 전송하여 알림을 수신할 수 있습니다.

**2번 사용자(로그인 한 사용자)가 SSE 접속을 한 상황**
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/a681c80f-ca95-49a7-b7df-2ff83573d62f" />
</br>

**1번 사용자가 2번 사용자 팔로우 요청**
<img width="443" alt="image" src="https://github.com/user-attachments/assets/d9345dc8-cc90-4816-8841-6f493871e0f9" />
</br>

**2번 사용자는 실시간으로 알림을 수신** 
<img width="1499" alt="image" src="https://github.com/user-attachments/assets/83dd2125-2ec2-45ca-bcc6-01e2ac5a3797" />

---

## 📝 Requirements for Reviewer

- yml 파일의 포트 값, DB의 name, password 등이 달라 협업 시 매번 수정을 하는 불편함이 생겨 해당 값 들은 .env로 옮겨서 작업 해 주세요
 - 또한 application-dev.yml, application-prod.yml 두 파일로 나눠 개발용, 배포용으로 나눠야 할 것 같습니다.  

---

## ✅ 체크리스트

- [ ] Jira 티켓 번호를 커밋 메시지에 포함했는가?
- [ ] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [ ] 불필요한 주석, 디버깅 코드 제거했는가?
- [ ] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)

> UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능)

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-67]: https://sh0314.atlassian.net/browse/GUC-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ